### PR TITLE
Set Greybird-geeko theme by default

### DIFF
--- a/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml
+++ b/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml
@@ -2,7 +2,7 @@
 
 <channel name="xfwm4" version="1.0">
   <property name="general" type="empty">
-    <property name="theme" type="string" value="Mint-Y-Dark-Teal"/>
+    <property name="theme" type="string" value="Greybird-geeko"/>
     <property name="title_font" type="string" value="Noto Sans Semi-Bold 11"/>
     <property name="double_click_time" type="int" value="400"/>
     <property name="use_compositing" type="bool" value="true"/>

--- a/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml
+++ b/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml
@@ -2,7 +2,7 @@
 
 <channel name="xfwm4" version="1.0">
   <property name="general" type="empty">
-    <property name="theme" type="string" value="Greybird-geeko"/>
+    <property name="theme" type="string" value="Greybird-Geeko-Light"/>
     <property name="title_font" type="string" value="Noto Sans Semi-Bold 11"/>
     <property name="double_click_time" type="int" value="400"/>
     <property name="use_compositing" type="bool" value="true"/>

--- a/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
+++ b/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
@@ -6,7 +6,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channel name="xsettings" version="1.0">
   <property name="Net" type="empty">
-    <property name="ThemeName" type="string" value="Greybird-geeko"/>
+    <property name="ThemeName" type="string" value="Greybird-Geeko-Light"/>
     <property name="IconThemeName" type="string" value="elementary-xfce-darker"/>
     <property name="DoubleClickTime" type="int" value="400"/>
     <property name="DoubleClickDistance" type="int" value="5"/>

--- a/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
+++ b/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
@@ -6,8 +6,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channel name="xsettings" version="1.0">
   <property name="Net" type="empty">
-    <property name="ThemeName" type="string" value="Mint-Y-Darker-Teal"/>
-    <property name="IconThemeName" type="string" value="elementary-xfce-dark"/>
+    <property name="ThemeName" type="string" value="Greybird-geeko"/>
+    <property name="IconThemeName" type="string" value="elementary-xfce-darker"/>
     <property name="DoubleClickTime" type="int" value="400"/>
     <property name="DoubleClickDistance" type="int" value="5"/>
     <property name="DndDragThreshold" type="int" value="8"/>


### PR DESCRIPTION
This theme is maintained by us (openSUSE Xfce Team) and it's forked from greybird GTK theme which is maintained directly by Xfce devs and often mentioned as  the "unofficial" Xfce Default. Greybird-geeko is part of the Shimmer project, which is the same home of the original greybird theme.

https://github.com/shimmerproject/

https://github.com/shimmerproject/Greybird-Geeko