### PR TITLE
Revert "Important: TW now uses png for default wallpaper boo#1222540"

### DIFF
--- a/base/usr/share/wallpapers/xfce/default.wallpaper
+++ b/base/usr/share/wallpapers/xfce/default.wallpaper
@@ -1,1 +1,1 @@
-/usr/share/wallpapers/openSUSEdefault/contents/images/1600x1200.png
+/usr/share/wallpapers/openSUSEdefault/contents/images/1600x1200.jpg


### PR DESCRIPTION
Reverts openSUSE/xfce4-branding-openSUSE#18

Wrong repo/version Implemented in https://code.opensuse.org/xfce/xfce4-branding-openSUSE/pull-request/1