### PR TITLE
Fix the slow start-up of Wayland session (bsc#1247542)

### DIFF
--- a/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
+++ b/base/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
@@ -44,4 +44,31 @@
   <property name="shutdown" type="empty">
     <property name="LockScreen" type="bool" value="true"/>
   </property>
+  <property name="sessions" type="empty">
+    <property name="FailsafeWayland" type="empty">
+      <property name="IsFailsafe" type="bool" value="true"/>
+      <property name="Count" type="int" value="4"/>
+      <property name="Client0_Command" type="array">
+        <value type="string" value="xfsettingsd"/>
+      </property>
+      <property name="Client0_Priority" type="int" value="15"/>
+      <property name="Client0_PerScreen" type="bool" value="false"/>
+      <property name="Client1_Command" type="array">
+        <value type="string" value="xfce4-panel"/>
+      </property>
+      <property name="Client1_Priority" type="int" value="15"/>
+      <property name="Client1_PerScreen" type="bool" value="false"/>
+      <property name="Client2_Command" type="array">
+        <value type="string" value="Thunar"/>
+        <value type="string" value="--daemon"/>
+      </property>
+      <property name="Client2_Priority" type="int" value="15"/>
+      <property name="Client2_PerScreen" type="bool" value="false"/>
+      <property name="Client3_Command" type="array">
+        <value type="string" value="xfdesktop"/>
+      </property>
+      <property name="Client3_Priority" type="int" value="15"/>
+      <property name="Client3_PerScreen" type="bool" value="false"/>
+    </property>
+  </property>
 </channel>


### PR DESCRIPTION
It's basically a cherry-pick of the upstream commit d5c8d7ed5da0 ("wayland: Adapt failsafe startup").